### PR TITLE
Add i3s dependency

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -27,6 +27,15 @@
           "revision": "80de9622b9bd1dca409b0e66e3ccc418676e571e",
           "version": "3.6.1"
         }
+      },
+      {
+        "package": "i3s",
+        "repositoryURL": "https://github.com/mwsrp/i3s-swift-package.git",
+        "state": {
+          "branch": null,
+          "revision": "44e29019ca18a1e7e73e972649d6b67b90a54e73",
+          "version": "1.3.0"
+        }
       }
     ]
   },

--- a/Package.resolved
+++ b/Package.resolved
@@ -11,6 +11,15 @@
         }
       },
       {
+        "package": "MySwift4Package",
+        "repositoryURL": "https://github.com/itsravenous/MySwift4Package.git",
+        "state": {
+          "branch": null,
+          "revision": "f82c932583b81d1c793142213cd64d035c1dbc5a",
+          "version": "1.0.0"
+        }
+      },
+      {
         "package": "RxSwift",
         "repositoryURL": "https://github.com/ReactiveX/RxSwift.git",
         "state": {

--- a/Package.resolved
+++ b/Package.resolved
@@ -2,6 +2,15 @@
   "object": {
     "pins": [
       {
+        "package": "MySwift3Package",
+        "repositoryURL": "https://github.com/itsravenous/MySwift3Package.git",
+        "state": {
+          "branch": null,
+          "revision": "50b06932901e02a7e66cdfe4ab2dc4ff9e87d505",
+          "version": "1.0.0"
+        }
+      },
+      {
         "package": "RxSwift",
         "repositoryURL": "https://github.com/ReactiveX/RxSwift.git",
         "state": {

--- a/Package.swift
+++ b/Package.swift
@@ -17,13 +17,14 @@ let package = Package(
         .package(url: "https://github.com/ReactiveX/RxSwift.git", from: "3.6.0"),
         .package(url: "https://github.com/itsravenous/MySwift3Package.git", from: "1.0.0"),
         .package(url: "https://github.com/itsravenous/MySwift4Package.git", from: "1.0.0"),
+        .package(url: "https://github.com/mwsrp/i3s-swift-package.git", from: "1.3.0"),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.
         // Targets can depend on other targets in this package, and on products in packages which this package depends on.
         .target(
             name: "Dependencies",
-            dependencies: ["RxSwift", "MySwift3Package", "MySwift4Package"],
+            dependencies: ["RxSwift", "MySwift3Package", "MySwift4Package", "I3sSwift"],
             path: ".deps-sources"
         )
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -15,13 +15,14 @@ let package = Package(
     dependencies: [
         // Dependencies declare other packages that this package depends on.
         .package(url: "https://github.com/ReactiveX/RxSwift.git", from: "3.6.0"),
+        .package(url: "https://github.com/itsravenous/MySwift3Package.git", from: "1.0.0"),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.
         // Targets can depend on other targets in this package, and on products in packages which this package depends on.
         .target(
             name: "Dependencies",
-            dependencies: ["RxSwift"],
+            dependencies: ["RxSwift", "MySwift3Package"],
             path: ".deps-sources"
         )
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -16,13 +16,14 @@ let package = Package(
         // Dependencies declare other packages that this package depends on.
         .package(url: "https://github.com/ReactiveX/RxSwift.git", from: "3.6.0"),
         .package(url: "https://github.com/itsravenous/MySwift3Package.git", from: "1.0.0"),
+        .package(url: "https://github.com/itsravenous/MySwift4Package.git", from: "1.0.0"),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.
         // Targets can depend on other targets in this package, and on products in packages which this package depends on.
         .target(
             name: "Dependencies",
-            dependencies: ["RxSwift", "MySwift3Package"],
+            dependencies: ["RxSwift", "MySwift3Package", "MySwift4Package"],
             path: ".deps-sources"
         )
     ]

--- a/SwiftPackagesWithiOS.xcodeproj/project.pbxproj
+++ b/SwiftPackagesWithiOS.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		034338351F45CCD200782A2F /* RxCocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0343382D1F45CCD200782A2F /* RxCocoa.framework */; };
 		034338361F45CCD200782A2F /* RxCocoaRuntime.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 034338311F45CCD200782A2F /* RxCocoaRuntime.framework */; };
 		034338371F45CCD200782A2F /* RxSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 034338331F45CCD200782A2F /* RxSwift.framework */; };
+		354BAD5B1F8A72BB003A301A /* MySwift4Package.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 354BAD5A1F8A72BB003A301A /* MySwift4Package.framework */; };
 		3570B6CB1F8A6B7400A87877 /* MySwift3Package.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3570B6C91F8A69C400A87877 /* MySwift3Package.framework */; };
 /* End PBXBuildFile section */
 
@@ -55,6 +56,13 @@
 			remoteGlobalIDString = "Dependencies::Dependencies::Product";
 			remoteInfo = Dependencies;
 		};
+		354BAD591F8A72BB003A301A /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0347D9E61F45C9EA0004D700 /* Dependencies.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = "MySwift4Package::MySwift4Package::Product";
+			remoteInfo = MySwift4Package;
+		};
 		3570B6C81F8A69C400A87877 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 0347D9E61F45C9EA0004D700 /* Dependencies.xcodeproj */;
@@ -80,6 +88,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				354BAD5B1F8A72BB003A301A /* MySwift4Package.framework in Frameworks */,
 				3570B6CB1F8A6B7400A87877 /* MySwift3Package.framework in Frameworks */,
 				034338341F45CCD200782A2F /* RxBlocking.framework in Frameworks */,
 				034338351F45CCD200782A2F /* RxCocoa.framework in Frameworks */,
@@ -126,6 +135,7 @@
 			isa = PBXGroup;
 			children = (
 				0347D9EC1F45C9EA0004D700 /* Dependencies.framework */,
+				354BAD5A1F8A72BB003A301A /* MySwift4Package.framework */,
 				3570B6C91F8A69C400A87877 /* MySwift3Package.framework */,
 				0343382D1F45CCD200782A2F /* RxCocoa.framework */,
 				0343382F1F45CCD200782A2F /* RxBlocking.framework */,
@@ -235,6 +245,13 @@
 			fileType = wrapper.framework;
 			path = Dependencies.framework;
 			remoteRef = 0347D9EB1F45C9EA0004D700 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		354BAD5A1F8A72BB003A301A /* MySwift4Package.framework */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.framework;
+			path = MySwift4Package.framework;
+			remoteRef = 354BAD591F8A72BB003A301A /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
 		3570B6C91F8A69C400A87877 /* MySwift3Package.framework */ = {

--- a/SwiftPackagesWithiOS.xcodeproj/project.pbxproj
+++ b/SwiftPackagesWithiOS.xcodeproj/project.pbxproj
@@ -13,11 +13,13 @@
 		03035A0D1F458E8B00961E46 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 03035A0C1F458E8B00961E46 /* Assets.xcassets */; };
 		03035A101F458E8B00961E46 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 03035A0E1F458E8B00961E46 /* LaunchScreen.storyboard */; };
 		034338341F45CCD200782A2F /* RxBlocking.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0343382F1F45CCD200782A2F /* RxBlocking.framework */; };
-		034338351F45CCD200782A2F /* RxCocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0343382D1F45CCD200782A2F /* RxCocoa.framework */; };
 		034338361F45CCD200782A2F /* RxCocoaRuntime.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 034338311F45CCD200782A2F /* RxCocoaRuntime.framework */; };
 		034338371F45CCD200782A2F /* RxSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 034338331F45CCD200782A2F /* RxSwift.framework */; };
 		354BAD5B1F8A72BB003A301A /* MySwift4Package.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 354BAD5A1F8A72BB003A301A /* MySwift4Package.framework */; };
 		3570B6CB1F8A6B7400A87877 /* MySwift3Package.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3570B6C91F8A69C400A87877 /* MySwift3Package.framework */; };
+		35CC278D1F8ABF81001C8B4F /* i3s_swift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 35BD5A071F8A77AA0032D857 /* i3s_swift.framework */; };
+		35CC278E1F8ABFB8001C8B4F /* i3s.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 35BD5A091F8A77AA0032D857 /* i3s.framework */; };
+		35E0E24C1F8AC81E00025B39 /* RxCocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0343382D1F45CCD200782A2F /* RxCocoa.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -70,6 +72,20 @@
 			remoteGlobalIDString = "MySwift3Package::MySwift3Package::Product";
 			remoteInfo = MySwift3Package;
 		};
+		35BD5A061F8A77AA0032D857 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0347D9E61F45C9EA0004D700 /* Dependencies.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = "i3s::i3s-swift::Product";
+			remoteInfo = "i3s-swift";
+		};
+		35BD5A081F8A77AA0032D857 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0347D9E61F45C9EA0004D700 /* Dependencies.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = "i3s::i3s::Product";
+			remoteInfo = i3s;
+		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
@@ -88,10 +104,12 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				35E0E24C1F8AC81E00025B39 /* RxCocoa.framework in Frameworks */,
+				35CC278E1F8ABFB8001C8B4F /* i3s.framework in Frameworks */,
+				35CC278D1F8ABF81001C8B4F /* i3s_swift.framework in Frameworks */,
 				354BAD5B1F8A72BB003A301A /* MySwift4Package.framework in Frameworks */,
 				3570B6CB1F8A6B7400A87877 /* MySwift3Package.framework in Frameworks */,
 				034338341F45CCD200782A2F /* RxBlocking.framework in Frameworks */,
-				034338351F45CCD200782A2F /* RxCocoa.framework in Frameworks */,
 				034338361F45CCD200782A2F /* RxCocoaRuntime.framework in Frameworks */,
 				034338371F45CCD200782A2F /* RxSwift.framework in Frameworks */,
 			);
@@ -135,6 +153,8 @@
 			isa = PBXGroup;
 			children = (
 				0347D9EC1F45C9EA0004D700 /* Dependencies.framework */,
+				35BD5A071F8A77AA0032D857 /* i3s_swift.framework */,
+				35BD5A091F8A77AA0032D857 /* i3s.framework */,
 				354BAD5A1F8A72BB003A301A /* MySwift4Package.framework */,
 				3570B6C91F8A69C400A87877 /* MySwift3Package.framework */,
 				0343382D1F45CCD200782A2F /* RxCocoa.framework */,
@@ -259,6 +279,20 @@
 			fileType = wrapper.framework;
 			path = MySwift3Package.framework;
 			remoteRef = 3570B6C81F8A69C400A87877 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		35BD5A071F8A77AA0032D857 /* i3s_swift.framework */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.framework;
+			path = i3s_swift.framework;
+			remoteRef = 35BD5A061F8A77AA0032D857 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		35BD5A091F8A77AA0032D857 /* i3s.framework */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.framework;
+			path = i3s.framework;
+			remoteRef = 35BD5A081F8A77AA0032D857 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
 /* End PBXReferenceProxy section */
@@ -422,6 +456,7 @@
 				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = SwiftPackagesWithiOS/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				OTHER_LDFLAGS = "-lc++";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.music-group.innouk.SwiftPackagesWithiOS";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 4.0;
@@ -436,6 +471,7 @@
 				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = SwiftPackagesWithiOS/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				OTHER_LDFLAGS = "-lc++";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.music-group.innouk.SwiftPackagesWithiOS";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 4.0;

--- a/SwiftPackagesWithiOS.xcodeproj/project.pbxproj
+++ b/SwiftPackagesWithiOS.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		034338351F45CCD200782A2F /* RxCocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0343382D1F45CCD200782A2F /* RxCocoa.framework */; };
 		034338361F45CCD200782A2F /* RxCocoaRuntime.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 034338311F45CCD200782A2F /* RxCocoaRuntime.framework */; };
 		034338371F45CCD200782A2F /* RxSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 034338331F45CCD200782A2F /* RxSwift.framework */; };
+		3570B6CB1F8A6B7400A87877 /* MySwift3Package.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3570B6C91F8A69C400A87877 /* MySwift3Package.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -54,6 +55,13 @@
 			remoteGlobalIDString = "Dependencies::Dependencies::Product";
 			remoteInfo = Dependencies;
 		};
+		3570B6C81F8A69C400A87877 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0347D9E61F45C9EA0004D700 /* Dependencies.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = "MySwift3Package::MySwift3Package::Product";
+			remoteInfo = MySwift3Package;
+		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
@@ -72,6 +80,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				3570B6CB1F8A6B7400A87877 /* MySwift3Package.framework in Frameworks */,
 				034338341F45CCD200782A2F /* RxBlocking.framework in Frameworks */,
 				034338351F45CCD200782A2F /* RxCocoa.framework in Frameworks */,
 				034338361F45CCD200782A2F /* RxCocoaRuntime.framework in Frameworks */,
@@ -88,6 +97,7 @@
 				0347D9E61F45C9EA0004D700 /* Dependencies.xcodeproj */,
 				03035A041F458E8B00961E46 /* SwiftPackagesWithiOS */,
 				03035A031F458E8B00961E46 /* Products */,
+				3570B6CA1F8A6B7400A87877 /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -116,12 +126,20 @@
 			isa = PBXGroup;
 			children = (
 				0347D9EC1F45C9EA0004D700 /* Dependencies.framework */,
+				3570B6C91F8A69C400A87877 /* MySwift3Package.framework */,
 				0343382D1F45CCD200782A2F /* RxCocoa.framework */,
 				0343382F1F45CCD200782A2F /* RxBlocking.framework */,
 				034338311F45CCD200782A2F /* RxCocoaRuntime.framework */,
 				034338331F45CCD200782A2F /* RxSwift.framework */,
 			);
 			name = Products;
+			sourceTree = "<group>";
+		};
+		3570B6CA1F8A6B7400A87877 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = Frameworks;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -217,6 +235,13 @@
 			fileType = wrapper.framework;
 			path = Dependencies.framework;
 			remoteRef = 0347D9EB1F45C9EA0004D700 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		3570B6C91F8A69C400A87877 /* MySwift3Package.framework */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.framework;
+			path = MySwift3Package.framework;
+			remoteRef = 3570B6C81F8A69C400A87877 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
 /* End PBXReferenceProxy section */

--- a/SwiftPackagesWithiOS/ViewController.swift
+++ b/SwiftPackagesWithiOS/ViewController.swift
@@ -12,6 +12,7 @@ import RxSwift
 import RxCocoa
 import MySwift3Package
 import MySwift4Package
+import i3s_swift
 
 class ViewController: UIViewController {
     @IBOutlet weak var slider: UISlider!
@@ -24,6 +25,7 @@ class ViewController: UIViewController {
         // Do any additional setup after loading the view, typically from a nib.
         print(SomeStruct.self)
         print(SomeOtherStruct.self)
+        print(FingerPrint(ref:[0.0, 0.0, 0.0, 0.0, 0.0, 0.0], data:[0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0], nr:1))
         slider.rx.value
             .bind(to: progressView.rx.progress)
             .disposed(by: bag)

--- a/SwiftPackagesWithiOS/ViewController.swift
+++ b/SwiftPackagesWithiOS/ViewController.swift
@@ -11,6 +11,7 @@ import UIKit
 import RxSwift
 import RxCocoa
 import MySwift3Package
+import MySwift4Package
 
 class ViewController: UIViewController {
     @IBOutlet weak var slider: UISlider!

--- a/SwiftPackagesWithiOS/ViewController.swift
+++ b/SwiftPackagesWithiOS/ViewController.swift
@@ -21,7 +21,7 @@ class ViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         // Do any additional setup after loading the view, typically from a nib.
-
+        print(SomeStruct.self)
         slider.rx.value
             .bind(to: progressView.rx.progress)
             .disposed(by: bag)

--- a/SwiftPackagesWithiOS/ViewController.swift
+++ b/SwiftPackagesWithiOS/ViewController.swift
@@ -10,6 +10,7 @@ import UIKit
 
 import RxSwift
 import RxCocoa
+import MySwift3Package
 
 class ViewController: UIViewController {
     @IBOutlet weak var slider: UISlider!

--- a/SwiftPackagesWithiOS/ViewController.swift
+++ b/SwiftPackagesWithiOS/ViewController.swift
@@ -23,6 +23,7 @@ class ViewController: UIViewController {
         super.viewDidLoad()
         // Do any additional setup after loading the view, typically from a nib.
         print(SomeStruct.self)
+        print(SomeOtherStruct.self)
         slider.rx.value
             .bind(to: progressView.rx.progress)
             .disposed(by: bag)


### PR DESCRIPTION
Through this, learned the steps for adding a new swift package dependency (probably an easier way to update the dependency project, but this works for now):

1. Add new dependency to `Package.swift` (in `dependencies` and to the list of dependencies for the app target)
2. `rm -rf .build/ Package.resolved Dependencies.xcodeproj && ruby generate-dependencies-project.rb` (probably a little extreme, will test and see if just deleting `Dependencies.xcodeproj` is sufficient)
3. Open `SwiftPackagesWithiOS.xcodeproj`
4. Go to "Build Phases" and add the dependency in "Link Binary With Libraries". In this case we needed to add both i3s_swift (the swift wrapper) and i3s (the C++ headers and implementation)
5. Should now be able to import and use the package

Note also the additional linker flag `-lc++` required because the i3s package includes C++ code