### PR TITLE
Update SPM dependencies

### DIFF
--- a/generate-dependencies-project.rb
+++ b/generate-dependencies-project.rb
@@ -2,6 +2,7 @@
 
 require 'xcodeproj'
 
+system "swift package update"
 system "swift package generate-xcodeproj"
 
 project = Xcodeproj::Project.open('Dependencies.xcodeproj')


### PR DESCRIPTION
Run `swift package update` before regenerate Xcode project. To make sure your dependencies stay up to date as described in SPM manifest.