### PR TITLE
Add multiple configuration support

### DIFF
--- a/generate-dependencies-project.rb
+++ b/generate-dependencies-project.rb
@@ -6,6 +6,23 @@ system "swift package generate-xcodeproj"
 
 project = Xcodeproj::Project.open('Dependencies.xcodeproj')
 
+# You will also need to edit the root project name
+root_project = Xcodeproj::Project.open('SwiftPackagesWithiOS.xcodeproj')
+
+# Adding the following build configuration from parent project to Dependencies.
+# If you are using multiple configurations for example `Beta` or `Staging`
+# Your Frameworks will be placed under correct Product build configuration 
+# /Build/Products/Staging-iphonesimulator/App.app/Frameworks
+build_configs = root_project.build_configurations.reject { |bc| bc.name == 'Debug' || bc.name == 'Release' }
+build_configs.each do |cf|
+    if project.build_configurations.find { |bc| bc.name == cf.name && bc.type == cf.type }
+      puts "Build configuration #{cf.name} already exists in #{File.basename(project.path)}"
+    else
+      puts "Adding the following build configuration to #{File.basename(project.path)}: #{cf.name}(#{cf.type})"
+      project.add_build_configuration(cf.name, cf.type)
+    end
+end
+
 project.targets.each do |target|
   module_map_file = "Dependencies.xcodeproj/GeneratedModuleMap/#{target.name}/module.modulemap"
 
@@ -16,6 +33,10 @@ project.targets.each do |target|
     # Remove this line if you prefer to link the dependencies dynamically
     # You will also need to embed the framework with the app bundle
     config.build_settings['MACH_O_TYPE'] = 'staticlib'
+
+    # Remove this line if you prefer to
+    # Add platfor support
+    config.build_settings['SUPPORTED_PLATFORMS'] = 'macosx iphoneos iphonesimulator appletvos appletvsimulator watchos watchsimulator'
 
     # Set MODULEMAP_FILE for non-Swift Frameworks
     #


### PR DESCRIPTION
I am using multiple configuration under my project based on selected custom scheme.

This script extensions rewrites names os a scheme to Dependencies project. 
Thanks to that framework is placed in correct location like: 
/Build/Products/Staging-iphonesimulator/App.app/Frameworks
for Staging configuration name

Moreover, I have added supported platform setup 
Thanks to that I am able to place script execution under build phases with shell script
`ruby "${SRCROOT}/swift-package-manager-ios.rb"`
before Compile Sources phase to My Main.xcodeproj. 

With all of that after your steps my project on build/run/archive/etc 
manages to update, and configure it self so my project work flow-less